### PR TITLE
Extract the ABI version from the target triple too, for Android and other platforms that use it

### DIFF
--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -27,7 +27,8 @@ public struct Triple: Encodable, Equatable {
     public let vendor: Vendor
     public let os: OS
     public let abi: ABI
-    public let version: String?
+    public let osVersion: String?
+    public let abiVersion: String?
 
     public enum Error: Swift.Error {
         case badFormat
@@ -84,16 +85,18 @@ public struct Triple: Encodable, Equatable {
             throw Error.unknownOS
         }
 
-        let version = Triple.parseVersion(components[2])
+        let osVersion = Triple.parseVersion(components[2])
 
         let abi = components.count > 3 ? Triple.parseABI(components[3]) : nil
+        let abiVersion = components.count > 3 ? Triple.parseVersion(components[3]) : nil
 
         self.tripleString = string
         self.arch = arch
         self.vendor = vendor
         self.os = os
-        self.version = version
+        self.osVersion = osVersion
         self.abi = abi ?? .unknown
+        self.abiVersion = abiVersion
     }
 
     fileprivate static func parseOS(_ string: String) -> OS? {
@@ -145,7 +148,7 @@ public struct Triple: Encodable, Equatable {
     /// This is currently meant for Apple platforms only.
     public func tripleString(forPlatformVersion version: String) -> String {
         precondition(isDarwin())
-        return String(self.tripleString.dropLast(self.version?.count ?? 0)) + version
+        return String(self.tripleString.dropLast(self.osVersion?.count ?? 0)) + version
     }
 
     public static let macOS = try! Triple("x86_64-apple-macosx")

--- a/Tests/TSCUtilityTests/TripleTests.swift
+++ b/Tests/TSCUtilityTests/TripleTests.swift
@@ -16,13 +16,18 @@ class TripleTests : XCTestCase {
         let linux = try? Triple("x86_64-unknown-linux-gnu")
         XCTAssertNotNil(linux)
         XCTAssertEqual(linux!.os, .linux)
-        XCTAssertNil(linux!.version)
+        XCTAssertNil(linux!.osVersion)
 
         let macos = try? Triple("x86_64-apple-macosx10.15")
         XCTAssertNotNil(macos!)
-        XCTAssertEqual(macos!.version, "10.15")
+        XCTAssertEqual(macos!.osVersion, "10.15")
         let newVersion = "10.12"
         let tripleString = macos!.tripleString(forPlatformVersion: newVersion)
         XCTAssertEqual(tripleString, "x86_64-apple-macosx10.12")
+
+        let android = try? Triple("aarch64-unknown-linux-android24")
+        XCTAssertNotNil(android)
+        XCTAssertEqual(android!.os, .linux)
+        XCTAssertEqual(android!.abiVersion, "24")
     }
 }


### PR DESCRIPTION
Tested this out by running these tests natively on Android 11, then modified SPM's bootstrap script to use the versioned triple and built and tested against this pull without a problem. 